### PR TITLE
Define mainClass in pom.xml to avoid needing to provide it later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -384,6 +384,10 @@ SOFTWARE.
                             -->
                             <transformers>
                                 <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.rml.framework.Main</mainClass>
+                                </transformer>
+                                <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                             </transformers>
                             <!-- If you want to use ./bin/flink run <quickstart jar> uncomment the following lines.


### PR DESCRIPTION
Define io.rml.framework.Main mainClass in pom.xml to avoid needing to provide it when running the job with Apache Flink UI

